### PR TITLE
[PPP-4865] - Changes to 4.2.15 - replacement of snakeyaml with safeyaml and removal of log4j:log4j

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -577,9 +577,9 @@ Apache Karaf 4.2.7 is an update on the 4.2.x series, bringing fixes, improvement
     * [KARAF-6415] - Upgrade to Aries Proxy 1.1.6
     * [KARAF-6426] - Upgrade to hibernate-validator 6.0.17.Final
 
-## Apache Karaf 4.2.6
+## Apache Karaf 4.2.15
 
-Apache Karaf 4.2.6 is an updte on the 4.2.x series, bringing fixes and updates.
+Apache Karaf 4.2.15 is an updte on the 4.2.x series, bringing fixes and updates.
 
 ### ChangeLog
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -577,9 +577,9 @@ Apache Karaf 4.2.7 is an update on the 4.2.x series, bringing fixes, improvement
     * [KARAF-6415] - Upgrade to Aries Proxy 1.1.6
     * [KARAF-6426] - Upgrade to hibernate-validator 6.0.17.Final
 
-## Apache Karaf 4.2.15
+## Apache Karaf 4.2.6
 
-Apache Karaf 4.2.15 is an updte on the 4.2.x series, bringing fixes and updates.
+Apache Karaf 4.2.6 is an updte on the 4.2.x series, bringing fixes and updates.
 
 ### ChangeLog
 

--- a/assemblies/features/framework/pom.xml
+++ b/assemblies/features/framework/pom.xml
@@ -177,8 +177,9 @@
             <artifactId>org.apache.karaf.features.extension</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.karaf.features</groupId>
-            <artifactId>org.apache.karaf.features.core</artifactId>
+            <groupId>org.hitachivantara.karaf.features</groupId>
+            <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>

--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -70,6 +70,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/assemblies/features/static/pom.xml
+++ b/assemblies/features/static/pom.xml
@@ -65,6 +65,12 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-service</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.services</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -28,6 +28,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <groupId>org.hitachivantara.karaf</groupId>
     <artifactId>karaf-bom</artifactId>
     <name>Apache Karaf :: BOM</name>
     <packaging>pom</packaging>
@@ -212,8 +213,8 @@
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.karaf.features</groupId>
-                <artifactId>org.apache.karaf.features.core</artifactId>
+                <groupId>org.hitachivantara.karaf.features</groupId>
+                <artifactId>org.hitachivantara.karaf.features.core</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
@@ -890,6 +891,12 @@
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-log4j12</artifactId>
                 <version>${slf4j.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -901,6 +908,12 @@
                 <groupId>org.ops4j.pax.logging</groupId>
                 <artifactId>pax-logging-service</artifactId>
                 <version>${pax.logging.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.ops4j.pax.logging</groupId>

--- a/deployer/features/pom.xml
+++ b/deployer/features/pom.xml
@@ -78,6 +78,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.felix</groupId>

--- a/deployer/kar/pom.xml
+++ b/deployer/kar/pom.xml
@@ -74,6 +74,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
 

--- a/diagnostic/core/pom.xml
+++ b/diagnostic/core/pom.xml
@@ -72,6 +72,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/etc/appended-resources/supplemental-models.xml
+++ b/etc/appended-resources/supplemental-models.xml
@@ -624,23 +624,6 @@
   </supplement>
   <supplement>
     <project>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <name>Log4j</name>
-      <organization>
-        <name>The Apache Software Foundation</name>
-        <url>http://www.apache.org/</url>
-      </organization>
-      <licenses>
-        <license>
-          <name>The Apache Software License, Version 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-      </licenses>
-    </project>
-  </supplement>
-  <supplement>
-    <project>
       <groupId>org.apache.geronimo.components</groupId>
       <artifactId>geronimo-connector</artifactId>
       <name>Apache Geronimo TxManager :: Connector</name> 

--- a/examples/karaf-log-appender-example/karaf-log-appender-example-core/pom.xml
+++ b/examples/karaf-log-appender-example/karaf-log-appender-example-core/pom.xml
@@ -48,6 +48,12 @@
         <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-service</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/examples/karaf-profile-example/karaf-profile-example-static/pom.xml
+++ b/examples/karaf-profile-example/karaf-profile-example-static/pom.xml
@@ -35,11 +35,26 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.apache.karaf</groupId>
+                <groupId>org.hitachivantara.karaf</groupId>
                 <artifactId>karaf-bom</artifactId>
                 <version>${project.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                </exclusions>
+
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -50,6 +65,20 @@
             <artifactId>static</artifactId>
             <type>kar</type>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
@@ -57,6 +86,21 @@
             <classifier>features</classifier>
             <type>xml</type>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.features</groupId>
@@ -64,11 +108,56 @@
             <classifier>features</classifier>
             <type>xml</type>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+
         </dependency>
 
         <dependency>
             <groupId>org.apache.karaf.services</groupId>
             <artifactId>org.apache.karaf.services.staticcm</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
     </dependencies>
 

--- a/features/command/pom.xml
+++ b/features/command/pom.xml
@@ -63,6 +63,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf.shell</groupId>

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -33,7 +33,6 @@
     <packaging>bundle</packaging>
     <name>Apache Karaf :: Features :: Core</name>
     <description>This bundle is the core implementation of the Karaf features support.</description>
-
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
     </properties>
@@ -117,6 +116,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/itests/common/pom.xml
+++ b/itests/common/pom.xml
@@ -94,8 +94,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.karaf.features</groupId>
-            <artifactId>org.apache.karaf.features.core</artifactId>
+            <groupId>org.hitachivantara.karaf.features</groupId>
+            <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -212,6 +212,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/jaas/blueprint/jasypt/pom.xml
+++ b/jaas/blueprint/jasypt/pom.xml
@@ -138,6 +138,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/jaas/jasypt/pom.xml
+++ b/jaas/jasypt/pom.xml
@@ -126,6 +126,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/jaas/modules/pom.xml
+++ b/jaas/modules/pom.xml
@@ -101,6 +101,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>
@@ -113,6 +119,22 @@
             <artifactId>apacheds-server-integ</artifactId>
             <version>${directory-version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>${log4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.directory.server</groupId>

--- a/jaas/spring-security-crypto/pom.xml
+++ b/jaas/spring-security-crypto/pom.xml
@@ -127,6 +127,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/management/server/pom.xml
+++ b/management/server/pom.xml
@@ -104,6 +104,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/maven/core/pom.xml
+++ b/maven/core/pom.xml
@@ -87,6 +87,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <camel.version>3.6.0</camel.version>
         <cglib.bundle.version>3.2.9_1</cglib.bundle.version>
         <cxf.version>3.4.3</cxf.version>
-        <jackson.version>2.12.5</jackson.version>
+        <jackson.version>2.14.2</jackson.version>
         <jna.version>5.9.0</jna.version>
         <jaxb.version>2.3.3</jaxb.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -317,7 +317,7 @@
         <pax.transx.version>0.5.0</pax.transx.version>
 
         <portlet-api.version>2.0</portlet-api.version>
-        <slf4j.version>1.7.29</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
 
         <spring.osgi.version>1.2.1</spring.osgi.version>
         <spring31.version>3.1.4.RELEASE</spring31.version>
@@ -344,6 +344,8 @@
 
         <websocket.version>1.1</websocket.version>
         <winsw.version>2.3.0</winsw.version>
+        <safeyaml.version>1.34.1</safeyaml.version>
+        <hv-jackson-dataformat.version>2.14.1</hv-jackson-dataformat.version>
 
         <surefire.argLine />
 
@@ -413,6 +415,32 @@
             <version>${easymock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hitachivantara</groupId>
+            <artifactId>safeyaml</artifactId>
+            <version>${safeyaml.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hitachivantara</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${hv-jackson-dataformat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/profile/pom.xml
+++ b/profile/pom.xml
@@ -97,6 +97,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
             <optional>true</optional>
         </dependency>
 
@@ -148,6 +149,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -77,6 +77,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -66,8 +66,8 @@
                 <version>${karaf.project.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.apache.karaf.features</groupId>
-                <artifactId>org.apache.karaf.features.core</artifactId>
+                <groupId>org.hitachivantara.karaf.features</groupId>
+                <artifactId>org.hitachivantara.karaf.features.core</artifactId>
                 <version>${karaf.project.version}</version>
             </dependency>
             <dependency>
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
-            <version>${karaf.project.version}</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <artifactId>org.apache.karaf.shell.console</artifactId>

--- a/webconsole/features/pom.xml
+++ b/webconsole/features/pom.xml
@@ -88,6 +88,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/webconsole/http/pom.xml
+++ b/webconsole/http/pom.xml
@@ -93,6 +93,7 @@
         <dependency>
             <groupId>org.hitachivantara.karaf.features</groupId>
             <artifactId>org.hitachivantara.karaf.features.core</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.karaf</groupId>


### PR DESCRIPTION
These changes include:
 - Replacing snakeyaml with SafeYaml (CVE-2022-1471)
 - Replacing jackson-dataformat-yaml with a HV patched version 2.14.1 ( with Safeyaml instead of snakeyaml )
 - Replacing of the log4j:log4j references with org.apache.log4j:log4j
 - Upgrade of the jackson core version ( missed in https://hv-eng.atlassian.net/browse/PPP-4782 )