### PR TITLE
[BACKLOG-41596] - Osgi extender osgi.component capability needs to be…

### DIFF
--- a/assemblies/features/standard/src/main/feature/feature.xml
+++ b/assemblies/features/standard/src/main/feature/feature.xml
@@ -1483,7 +1483,7 @@ org.apache.felix.eventadmin.AddSubject=true
         </conditional>
         <capability>
             osgi.service;effective:=active;objectClass=org.apache.felix.scr.ScrService,
-            osgi.extender;osgi.extender="osgi.component";uses:="org.osgi.service.component";version:Version="1.2.1"
+            osgi.extender;osgi.extender="osgi.component";uses:="org.osgi.service.component";version:Version="${org.osgi.service.component.version}"
         </capability>
     </feature>
 


### PR DESCRIPTION
… upgraded to the latest osgi component version as it is required by EhCache 3 and some of the latest libraries