### PR TITLE
[PPP-5589] [PPP-5618] Vulnerable Component: commons-io (Karaf)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,10 +308,10 @@
 
         <pax.cdi.version>1.1.4</pax.cdi.version>
         <pax.exam.version>4.13.5</pax.exam.version>
-        <pax.logging.version>2.2.7</pax.logging.version>
+        <pax.logging.version>2.2.8</pax.logging.version>
         <pax.base.version>1.5.1</pax.base.version>
         <pax.swissbox.version>1.8.5</pax.swissbox.version>
-        <pax.url.version>2.6.14</pax.url.version>
+        <pax.url.version>2.6.16</pax.url.version>
         <pax.web.version>8.0.30</pax.web.version>
         <pax.tinybundle.version>3.0.0</pax.tinybundle.version>
         <pax.jdbc.version>1.5.7</pax.jdbc.version>

--- a/tooling/karaf-maven-plugin/src/it/test-basic-generation/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-basic-generation/pom.xml
@@ -33,7 +33,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.hitachivantara.maven.plugins</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>1.8</source>
@@ -49,7 +49,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-check-dependencies/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-check-dependencies/pom.xml
@@ -41,7 +41,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.hitachivantara.maven.plugins</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>1.8</source>
@@ -56,7 +56,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/pom.xml
@@ -36,7 +36,7 @@
             <dependency>
                 <groupId>org.apache.karaf.shell</groupId>
                 <artifactId>org.apache.karaf.shell.core</artifactId>
-                <version>@karaf.project@</version>
+                <version>@karaf.project.version@</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/test-markdown/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-commands-generate-help/test-markdown/pom.xml
@@ -53,7 +53,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-feature-dependencies/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-feature-dependencies/pom.xml
@@ -44,7 +44,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.hitachivantara.maven.plugins</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <source>1.8</source>
@@ -59,7 +59,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-run-bundle/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-run-bundle/pom.xml
@@ -52,7 +52,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/pom.xml
@@ -68,7 +68,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-a/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-a/pom.xml
@@ -49,7 +49,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-as-is/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-as-is/pom.xml
@@ -49,7 +49,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-reduced/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-feature-reduced/pom.xml
@@ -49,7 +49,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-features/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-simplify-bundles/simplify-features/pom.xml
@@ -58,7 +58,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/pom.xml
@@ -57,7 +57,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/transitive-as-dependency-feature/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-transitive-as-dependency/transitive-as-dependency-feature/pom.xml
@@ -54,7 +54,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <extensions>true</extensions>

--- a/tooling/karaf-maven-plugin/src/it/test-type-classifier/pom.xml
+++ b/tooling/karaf-maven-plugin/src/it/test-type-classifier/pom.xml
@@ -51,7 +51,7 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <executions>

--- a/tooling/karaf-maven-plugin/src/site/apt/usage.apt
+++ b/tooling/karaf-maven-plugin/src/site/apt/usage.apt
@@ -65,7 +65,7 @@ Packagings
 
 +---+
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <configuration>
                     <startLevel>50</startLevel>
@@ -178,7 +178,7 @@ Packagings
 
 +---+
             <plugin>
-                <groupId>org.apache.karaf.tooling</groupId>
+                <groupId>org.hitachivantara.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
                 <configuration>
                     <defaultStartLevel>50</defaultStartLevel>


### PR DESCRIPTION
- Update pax-url-aether version: 2.6.14 -> 2.6.16
- Update pax-logging version: 2.2.7 -> 2.2.8
-- change made to address logback vulnerability associated with the pax-url-aether version, pax-logging 2.2.8 brings 1.3.15, which appears secure, we will have to see what our scans say
- Fix groupId for maven-compiler-plugin: it's from apache, we don't have a version of this afaik
- Fix groupId for karaf-maven-plugin: we do have a version of this, I followed this change https://github.com/pentaho/karaf/commit/a81ce57af928a2b7b4fbf17725a742f5f71e05de
- Fix version parameter used in test-commands-generate-help/pom.xml