### PR TITLE
build[PPP-5769]: Update commons-fileupload to 1.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.i??
 .idea
+.vscode
 .project
 .classpath
 .settings

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Version | Date | Changes
 4.4.6-2025.04.04 | 4/04/2025 | Upgraded Camel to 3.22.4 ([PPP-5635](https://hv-eng.atlassian.net/browse/PPP-5635))
 4.4.6-2025.06.11 | 6/11/2025 | Upgraded Pax Web to 8.0.32 ([PPP-5709](https://hv-eng.atlassian.net/browse/PPP-5709))
 4.4.6-2025.07.01 | 7/01/2025 | Upgraded Commons BeanUtils to 1.11.0 ([PPP-5731](https://hv-eng.atlassian.net/browse/PPP-5731))
+4.4.6-2025.08.05 | 8/05/2025 | Upgraded Commons FileUpload to 1.6.0 ([PPP-5769](https://hv-eng.atlassian.net/browse/PPP-5769))
 
 ## Vulnerabilities addressed by Pentaho after the fork:
 

--- a/archetypes/assembly/pom.xml
+++ b/archetypes/assembly/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <groupId>org.apache.karaf.archetypes</groupId>

--- a/archetypes/blueprint/pom.xml
+++ b/archetypes/blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/bundle/pom.xml
+++ b/archetypes/bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/command/pom.xml
+++ b/archetypes/command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/feature/pom.xml
+++ b/archetypes/feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/kar/pom.xml
+++ b/archetypes/kar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf</groupId>
         <artifactId>archetypes</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/archetypes/pom.xml
+++ b/archetypes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/apache-karaf-minimal/pom.xml
+++ b/assemblies/apache-karaf-minimal/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies</groupId>
         <artifactId>assemblies</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/apache-karaf/pom.xml
+++ b/assemblies/apache-karaf/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies</groupId>
         <artifactId>assemblies</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/base/pom.xml
+++ b/assemblies/features/base/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/enterprise/pom.xml
+++ b/assemblies/features/enterprise/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/framework/pom.xml
+++ b/assemblies/features/framework/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/assemblies/features/pom.xml
+++ b/assemblies/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies</groupId>
         <artifactId>assemblies</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/specs/pom.xml
+++ b/assemblies/features/specs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/spring-legacy/pom.xml
+++ b/assemblies/features/spring-legacy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/spring/pom.xml
+++ b/assemblies/features/spring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/features/standard/pom.xml
+++ b/assemblies/features/standard/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -38,7 +38,7 @@
         <appendedResourcesDirectory>${basedir}/../../../../etc/appended-resources</appendedResourcesDirectory>
         <javax.annotation.version>1.3</javax.annotation.version>
         <geronimo.jaspic-spec.version>1.1</geronimo.jaspic-spec.version>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/assemblies/features/static/pom.xml
+++ b/assemblies/features/static/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.assemblies.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/audit/pom.xml
+++ b/audit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/blueprintstate/pom.xml
+++ b/bundle/blueprintstate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.bundle</groupId>
         <artifactId>bundle</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/core/pom.xml
+++ b/bundle/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.bundle</groupId>
         <artifactId>bundle</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/springstate/pom.xml
+++ b/bundle/springstate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.bundle</groupId>
         <artifactId>bundle</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/config/command/pom.xml
+++ b/config/command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.config</groupId>
         <artifactId>config</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/config/core/pom.xml
+++ b/config/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.config</groupId>
         <artifactId>config</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/blueprint/pom.xml
+++ b/deployer/blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.deployer</groupId>
         <artifactId>deployer</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/features/pom.xml
+++ b/deployer/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.deployer</groupId>
         <artifactId>deployer</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/kar/pom.xml
+++ b/deployer/kar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.deployer</groupId>
         <artifactId>deployer</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/pom.xml
+++ b/deployer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/spring/pom.xml
+++ b/deployer/spring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.deployer</groupId>
         <artifactId>deployer</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/deployer/wrap/pom.xml
+++ b/deployer/wrap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.deployer</groupId>
         <artifactId>deployer</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/diagnostic/boot/pom.xml
+++ b/diagnostic/boot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.diagnostic</groupId>
         <artifactId>diagnostic</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/diagnostic/core/pom.xml
+++ b/diagnostic/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.diagnostic</groupId>
         <artifactId>diagnostic</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/diagnostic/pom.xml
+++ b/diagnostic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf</artifactId>
         <groupId>org.hitachivantara.karaf</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-blueprint-example/karaf-blueprint-example-client/pom.xml
+++ b/examples/karaf-blueprint-example/karaf-blueprint-example-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-blueprint-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-blueprint-example/karaf-blueprint-example-common/pom.xml
+++ b/examples/karaf-blueprint-example/karaf-blueprint-example-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-blueprint-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-blueprint-example/karaf-blueprint-example-features/pom.xml
+++ b/examples/karaf-blueprint-example/karaf-blueprint-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-blueprint-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-blueprint-example/karaf-blueprint-example-provider/pom.xml
+++ b/examples/karaf-blueprint-example/karaf-blueprint-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-blueprint-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-blueprint-example/pom.xml
+++ b/examples/karaf-blueprint-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-branding-example/pom.xml
+++ b/examples/karaf-branding-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-bundle-example/karaf-bundle-example-client/pom.xml
+++ b/examples/karaf-bundle-example/karaf-bundle-example-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-bundle-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-bundle-example/karaf-bundle-example-common/pom.xml
+++ b/examples/karaf-bundle-example/karaf-bundle-example-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-bundle-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-bundle-example/karaf-bundle-example-features/pom.xml
+++ b/examples/karaf-bundle-example/karaf-bundle-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-bundle-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-bundle-example/karaf-bundle-example-provider/pom.xml
+++ b/examples/karaf-bundle-example/karaf-bundle-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-bundle-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-bundle-example/pom.xml
+++ b/examples/karaf-bundle-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-camel-example/karaf-camel-example-blueprint/pom.xml
+++ b/examples/karaf-camel-example/karaf-camel-example-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-camel-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-camel-example/karaf-camel-example-features/pom.xml
+++ b/examples/karaf-camel-example/karaf-camel-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-camel-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-camel-example/karaf-camel-example-java/pom.xml
+++ b/examples/karaf-camel-example/karaf-camel-example-java/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-camel-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-camel-example/pom.xml
+++ b/examples/karaf-camel-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-cdi-example/karaf-cdi-example-api/pom.xml
+++ b/examples/karaf-cdi-example/karaf-cdi-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-cdi-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-cdi-example/karaf-cdi-example-consumer/pom.xml
+++ b/examples/karaf-cdi-example/karaf-cdi-example-consumer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-cdi-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-cdi-example/karaf-cdi-example-features/pom.xml
+++ b/examples/karaf-cdi-example/karaf-cdi-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-cdi-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-cdi-example/karaf-cdi-example-provider/pom.xml
+++ b/examples/karaf-cdi-example/karaf-cdi-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-cdi-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-cdi-example/pom.xml
+++ b/examples/karaf-cdi-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-command-example/karaf-command-example-api/pom.xml
+++ b/examples/karaf-command-example/karaf-command-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-command-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-command-example/karaf-command-example-command/pom.xml
+++ b/examples/karaf-command-example/karaf-command-example-command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-command-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-command-example/karaf-command-example-features/pom.xml
+++ b/examples/karaf-command-example/karaf-command-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-command-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-command-example/karaf-command-example-provider/pom.xml
+++ b/examples/karaf-command-example/karaf-command-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-command-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-command-example/pom.xml
+++ b/examples/karaf-command-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-blueprint/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-features/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-listener/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-listener/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-managed-factory/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-managed-factory/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-managed/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-managed/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-scr/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/karaf-config-example-static/pom.xml
+++ b/examples/karaf-config-example/karaf-config-example-static/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-config-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-config-example/pom.xml
+++ b/examples/karaf-config-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-deployer-example/pom.xml
+++ b/examples/karaf-deployer-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-docker-example/karaf-docker-example-app/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-docker-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-docker-example/karaf-docker-example-dynamic-dist/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-dynamic-dist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-docker-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
+++ b/examples/karaf-docker-example/karaf-docker-example-static-dist/pom.xml
@@ -24,7 +24,7 @@
     <parent>
        <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-docker-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-docker-example/pom.xml
+++ b/examples/karaf-docker-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-dump-example/pom.xml
+++ b/examples/karaf-dump-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-api/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-graphql-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-commands/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-commands/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-graphql-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-core/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf-graphql-example</artifactId>
         <groupId>org.apache.karaf.examples</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-features/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf-graphql-example</artifactId>
         <groupId>org.apache.karaf.examples</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-scr-servlet/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-scr-servlet/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf-graphql-example</artifactId>
         <groupId>org.apache.karaf.examples</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
+++ b/examples/karaf-graphql-example/karaf-graphql-example-websocket/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf-graphql-example</artifactId>
         <groupId>org.apache.karaf.examples</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-graphql-example/pom.xml
+++ b/examples/karaf-graphql-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-http-resource-example/karaf-http-resource-example-features/pom.xml
+++ b/examples/karaf-http-resource-example/karaf-http-resource-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-http-resource-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-http-resource-example/karaf-http-resource-example-whiteboard/pom.xml
+++ b/examples/karaf-http-resource-example/karaf-http-resource-example-whiteboard/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-http-resource-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-http-resource-example/pom.xml
+++ b/examples/karaf-http-resource-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-itest-example/pom.xml
+++ b/examples/karaf-itest-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jaas-example/karaf-jaas-example-app/pom.xml
+++ b/examples/karaf-jaas-example/karaf-jaas-example-app/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jaas-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jaas-example/karaf-jaas-example-features/pom.xml
+++ b/examples/karaf-jaas-example/karaf-jaas-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jaas-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jaas-example/karaf-jaas-example-wab/pom.xml
+++ b/examples/karaf-jaas-example/karaf-jaas-example-wab/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jaas-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jaas-example/karaf-jaas-example-war/pom.xml
+++ b/examples/karaf-jaas-example/karaf-jaas-example-war/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jaas-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jaas-example/pom.xml
+++ b/examples/karaf-jaas-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jdbc-example/karaf-jdbc-example-api/pom.xml
+++ b/examples/karaf-jdbc-example/karaf-jdbc-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jdbc-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jdbc-example/karaf-jdbc-example-command/pom.xml
+++ b/examples/karaf-jdbc-example/karaf-jdbc-example-command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jdbc-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jdbc-example/karaf-jdbc-example-features/pom.xml
+++ b/examples/karaf-jdbc-example/karaf-jdbc-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jdbc-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jdbc-example/karaf-jdbc-example-provider/pom.xml
+++ b/examples/karaf-jdbc-example/karaf-jdbc-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jdbc-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jdbc-example/pom.xml
+++ b/examples/karaf-jdbc-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jms-example/karaf-jms-example-command/pom.xml
+++ b/examples/karaf-jms-example/karaf-jms-example-command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jms-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jms-example/karaf-jms-example-features/pom.xml
+++ b/examples/karaf-jms-example/karaf-jms-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jms-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jms-example/pom.xml
+++ b/examples/karaf-jms-example/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-command/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-features/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-api/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-api/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-eclipselink/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-blueprint</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-hibernate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-blueprint</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/karaf-jpa-example-provider-blueprint-openjpa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-blueprint</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-blueprint/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-eclipselink/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-ds</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-hibernate/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-ds</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/karaf-jpa-example-provider-ds-openjpa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider-ds</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/karaf-jpa-example-provider-ds/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example-provider</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/karaf-jpa-example-provider/pom.xml
+++ b/examples/karaf-jpa-example/karaf-jpa-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-jpa-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-jpa-example/pom.xml
+++ b/examples/karaf-jpa-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-log-appender-example/karaf-log-appender-example-core/pom.xml
+++ b/examples/karaf-log-appender-example/karaf-log-appender-example-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-log-appender-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-log-appender-example/karaf-log-appender-example-features/pom.xml
+++ b/examples/karaf-log-appender-example/karaf-log-appender-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-log-appender-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-log-appender-example/pom.xml
+++ b/examples/karaf-log-appender-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-maven-example/karaf-maven-example-run-bundle/pom.xml
+++ b/examples/karaf-maven-example/karaf-maven-example-run-bundle/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-maven-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-maven-example/karaf-maven-example-run/pom.xml
+++ b/examples/karaf-maven-example/karaf-maven-example-run/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-maven-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-maven-example/pom.xml
+++ b/examples/karaf-maven-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-api/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-blueprint/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-features/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-provider/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-scr/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/karaf-mbean-example-simple/pom.xml
+++ b/examples/karaf-mbean-example/karaf-mbean-example-simple/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-mbean-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-mbean-example/pom.xml
+++ b/examples/karaf-mbean-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-redis-example/karaf-redis-example-api/pom.xml
+++ b/examples/karaf-redis-example/karaf-redis-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-redis-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-redis-example/karaf-redis-example-command/pom.xml
+++ b/examples/karaf-redis-example/karaf-redis-example-command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-redis-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-redis-example/karaf-redis-example-features/pom.xml
+++ b/examples/karaf-redis-example/karaf-redis-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-redis-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-redis-example/karaf-redis-example-service/pom.xml
+++ b/examples/karaf-redis-example/karaf-redis-example-service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-redis-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-redis-example/pom.xml
+++ b/examples/karaf-redis-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-api/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-blueprint/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-cxf/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.apache.karaf.examples</groupId>
 		<artifactId>karaf-rest-example-client</artifactId>
-		<version>4.4.6-2025.07.01</version>
+		<version>4.4.6-2025.08.05</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example-client</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/karaf-rest-example-client-jersey/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example-client</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-client/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-features/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/karaf-rest-example-whiteboard/pom.xml
+++ b/examples/karaf-rest-example/karaf-rest-example-whiteboard/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-rest-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-rest-example/pom.xml
+++ b/examples/karaf-rest-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scheduler-example/karaf-scheduler-example-features/pom.xml
+++ b/examples/karaf-scheduler-example/karaf-scheduler-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scheduler-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/pom.xml
+++ b/examples/karaf-scheduler-example/karaf-scheduler-example-runnable/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scheduler-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scheduler-example/pom.xml
+++ b/examples/karaf-scheduler-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scr-example/karaf-scr-example-api/pom.xml
+++ b/examples/karaf-scr-example/karaf-scr-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scr-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scr-example/karaf-scr-example-client/pom.xml
+++ b/examples/karaf-scr-example/karaf-scr-example-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scr-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scr-example/karaf-scr-example-features/pom.xml
+++ b/examples/karaf-scr-example/karaf-scr-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scr-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scr-example/karaf-scr-example-provider/pom.xml
+++ b/examples/karaf-scr-example/karaf-scr-example-provider/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-scr-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-scr-example/pom.xml
+++ b/examples/karaf-scr-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-annotation/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-annotation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-blueprint/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-features/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-registration/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-registration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-scr/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/karaf-servlet-example-upload/pom.xml
+++ b/examples/karaf-servlet-example/karaf-servlet-example-upload/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-servlet-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-servlet-example/pom.xml
+++ b/examples/karaf-servlet-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-soap-example/karaf-soap-example-api/pom.xml
+++ b/examples/karaf-soap-example/karaf-soap-example-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-soap-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-soap-example/karaf-soap-example-client/pom.xml
+++ b/examples/karaf-soap-example/karaf-soap-example-client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-soap-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-soap-example/karaf-soap-example-features/pom.xml
+++ b/examples/karaf-soap-example/karaf-soap-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-soap-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-soap-example/pom.xml
+++ b/examples/karaf-soap-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-url-namespace-handler-example/karaf-url-namespace-handler-example-core/pom.xml
+++ b/examples/karaf-url-namespace-handler-example/karaf-url-namespace-handler-example-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-url-namespace-handler-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-url-namespace-handler-example/karaf-url-namespace-handler-example-features/pom.xml
+++ b/examples/karaf-url-namespace-handler-example/karaf-url-namespace-handler-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-url-namespace-handler-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-url-namespace-handler-example/pom.xml
+++ b/examples/karaf-url-namespace-handler-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-war-example/karaf-war-example-features/pom.xml
+++ b/examples/karaf-war-example/karaf-war-example-features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-war-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-war-example/karaf-war-example-webapp/pom.xml
+++ b/examples/karaf-war-example/karaf-war-example-webapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>karaf-war-example</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-war-example/pom.xml
+++ b/examples/karaf-war-example/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/karaf-websocket-example/pom.xml
+++ b/examples/karaf-websocket-example/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.examples</groupId>
         <artifactId>apache-karaf-examples</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/command/pom.xml
+++ b/features/command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/core/pom.xml
+++ b/features/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/extension/pom.xml
+++ b/features/extension/pom.xml
@@ -24,12 +24,12 @@
     <parent>
         <groupId>org.apache.karaf.features</groupId>
         <artifactId>features</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.hitachivantara.karaf.features</groupId>
     <artifactId>org.hitachivantara.karaf.features.extension</artifactId>
-    <version>4.4.6-2025.07.01</version>
+    <version>4.4.6-2025.08.05</version>
     <packaging>bundle</packaging>
     <name>Apache Karaf :: Features :: Extension (Hitachi patched version)</name>
     <description>This bundle is an extension bundle for the framework.</description>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/instance/pom.xml
+++ b/instance/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/itests/common/pom.xml
+++ b/itests/common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/itests/test/pom.xml
+++ b/itests/test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.itests</groupId>
         <artifactId>itests</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/blueprint/config/pom.xml
+++ b/jaas/blueprint/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas.blueprint</groupId>
         <artifactId>blueprint</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/blueprint/jasypt/pom.xml
+++ b/jaas/blueprint/jasypt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas.blueprint</groupId>
         <artifactId>blueprint</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/jaas/blueprint/pom.xml
+++ b/jaas/blueprint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/boot/pom.xml
+++ b/jaas/boot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/command/pom.xml
+++ b/jaas/command/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>jaas</artifactId>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/jaas/config/pom.xml
+++ b/jaas/config/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/jasypt/pom.xml
+++ b/jaas/jasypt/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
     
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/jaas/modules/pom.xml
+++ b/jaas/modules/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/pom.xml
+++ b/jaas/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jaas/spring-security-crypto/pom.xml
+++ b/jaas/spring-security-crypto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.jaas</groupId>
         <artifactId>jaas</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -36,7 +36,7 @@
     
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/jndi/pom.xml
+++ b/jndi/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/kar/pom.xml
+++ b/kar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/log/pom.xml
+++ b/log/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/management/server/pom.xml
+++ b/management/server/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.management</groupId>
         <artifactId>management</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/manual/pom.xml
+++ b/manual/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<groupId>org.hitachivantara.karaf</groupId>
 		<artifactId>karaf</artifactId>
-		<version>4.4.6-2025.07.01</version>
+		<version>4.4.6-2025.08.05</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/maven/core/pom.xml
+++ b/maven/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/obr/pom.xml
+++ b/obr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <groupId>org.hitachivantara.karaf</groupId>
     <artifactId>karaf</artifactId>
     <packaging>pom</packaging>
-    <version>4.4.6-2025.07.01</version>
+    <version>4.4.6-2025.08.05</version>
     <name>Apache Karaf</name>
     <inceptionYear>2007</inceptionYear>
 
@@ -84,7 +84,7 @@
         <connection>${scm.connection}</connection>
         <developerConnection>${scm.developerConnection}</developerConnection>
         <url>${scm.url}</url>
-        <tag>karaf-4.4.6-2025.07.01</tag>
+        <tag>karaf-4.4.6-2025.08.05</tag>
     </scm>
 
     <distributionManagement>
@@ -370,7 +370,7 @@
         <obrRepository>NONE</obrRepository>
 
         <karaf.project.version>4.4.6</karaf.project.version>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
         <jetty.version>9.4.57.v20241219</jetty.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
         <commons-codec.version>1.15</commons-codec.version>
         <commons-compress.version>1.26.1</commons-compress.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-fileupload.version>1.5</commons-fileupload.version>
+        <commons-fileupload.version>1.6.0</commons-fileupload.version>
         <commons-lang3.version>3.14.0</commons-lang3.version>
         <commons-logging.version>1.3.1</commons-logging.version>
         <commons-pool2.version>2.11.1</commons-pool2.version>

--- a/profile/pom.xml
+++ b/profile/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scr/management/pom.xml
+++ b/scr/management/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.scr</groupId>
         <artifactId>scr</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scr/pom.xml
+++ b/scr/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/scr/state/pom.xml
+++ b/scr/state/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.scr</groupId>
         <artifactId>scr</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service/core/pom.xml
+++ b/service/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.service</groupId>
         <artifactId>service</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service/guard/pom.xml
+++ b/service/guard/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.service</groupId>
         <artifactId>service</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/services/coordinator/pom.xml
+++ b/services/coordinator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf</artifactId>
         <groupId>org.hitachivantara.karaf</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/services/eventadmin/pom.xml
+++ b/services/eventadmin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf</artifactId>
         <groupId>org.hitachivantara.karaf</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/services/interceptor/api/pom.xml
+++ b/services/interceptor/api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.services</groupId>
         <artifactId>org.apache.karaf.services.interceptor</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/services/interceptor/impl/pom.xml
+++ b/services/interceptor/impl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.services</groupId>
         <artifactId>org.apache.karaf.services.interceptor</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/services/interceptor/pom.xml
+++ b/services/interceptor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.services</groupId>
         <artifactId>services</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/services/staticcm/pom.xml
+++ b/services/staticcm/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>karaf</artifactId>
         <groupId>org.hitachivantara.karaf</groupId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/shell/commands/pom.xml
+++ b/shell/commands/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shell/console/pom.xml
+++ b/shell/console/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/shell/core/pom.xml
+++ b/shell/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shell/groovy/pom.xml
+++ b/shell/groovy/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shell/pom.xml
+++ b/shell/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/shell/ssh/pom.xml
+++ b/shell/ssh/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/shell/table/pom.xml
+++ b/shell/table/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.shell</groupId>
         <artifactId>shell</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/specs/activator/pom.xml
+++ b/specs/activator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.specs</groupId>
         <artifactId>specs</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <artifactId>org.apache.karaf.specs.activator</artifactId>

--- a/specs/java.xml.ws/pom.xml
+++ b/specs/java.xml.ws/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.specs</groupId>
         <artifactId>specs</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <artifactId>org.apache.karaf.specs.java.xml.ws</artifactId>

--- a/specs/java.xml/pom.xml
+++ b/specs/java.xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.specs</groupId>
         <artifactId>specs</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <artifactId>org.apache.karaf.specs.java.xml</artifactId>

--- a/specs/locator/pom.xml
+++ b/specs/locator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.specs</groupId>
         <artifactId>specs</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <artifactId>org.apache.karaf.specs.locator</artifactId>

--- a/specs/pom.xml
+++ b/specs/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/subsystem/pom.xml
+++ b/subsystem/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <groupId>org.apache.karaf.subsystem</groupId>

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tooling/karaf-maven-plugin/pom.xml
+++ b/tooling/karaf-maven-plugin/pom.xml
@@ -24,13 +24,13 @@
     <parent>
         <groupId>org.hitachivantara.karaf.tooling</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.hitachivantara.karaf.tooling</groupId>
     <artifactId>karaf-maven-plugin</artifactId>
-    <version>4.4.6-2025.07.01</version>
+    <version>4.4.6-2025.08.05</version>
     <packaging>maven-plugin</packaging>
     <name>Apache Karaf :: Tooling :: Maven Karaf Plugin</name>
 

--- a/tooling/karaf-services-maven-plugin/pom.xml
+++ b/tooling/karaf-services-maven-plugin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.tooling</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tooling/pom.xml
+++ b/tooling/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tooling/utils/pom.xml
+++ b/tooling/utils/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf.tooling</groupId>
         <artifactId>tooling</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
     </parent>
 
     <artifactId>org.apache.karaf.tools.utils</artifactId>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/webconsole/console/pom.xml
+++ b/webconsole/console/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.webconsole</groupId>
         <artifactId>webconsole</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${project.basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/webconsole/features/pom.xml
+++ b/webconsole/features/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.webconsole</groupId>
         <artifactId>webconsole</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/webconsole/gogo/pom.xml
+++ b/webconsole/gogo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.webconsole</groupId>
         <artifactId>webconsole</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -35,7 +35,7 @@
 
     <properties>
         <appendedResourcesDirectory>${basedir}/../../etc/appended-resources</appendedResourcesDirectory>
-        <pentaho-apache-karaf.version>4.4.6-2025.07.01</pentaho-apache-karaf.version>
+        <pentaho-apache-karaf.version>4.4.6-2025.08.05</pentaho-apache-karaf.version>
     </properties>
 
     <dependencyManagement>

--- a/webconsole/http/pom.xml
+++ b/webconsole/http/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.karaf.webconsole</groupId>
         <artifactId>webconsole</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/webconsole/instance/pom.xml
+++ b/webconsole/instance/pom.xml
@@ -19,7 +19,7 @@
 	<parent>
 		<groupId>org.apache.karaf.webconsole</groupId>
 		<artifactId>webconsole</artifactId>
-		<version>4.4.6-2025.07.01</version>
+		<version>4.4.6-2025.08.05</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/webconsole/pom.xml
+++ b/webconsole/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.hitachivantara.karaf</groupId>
         <artifactId>karaf</artifactId>
-        <version>4.4.6-2025.07.01</version>
+        <version>4.4.6-2025.08.05</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This pull request makes a minor update to the `pom.xml` file, upgrading the `commons-fileupload` dependency from version 1.5 to 1.6.0. This changes is required, as stated in PPP-5769, to address CVE-2025-48976.

Bumped pentaho/karaf version to 4.4.6-2025.08.05

Also added `.vscode` to `.gitignore`, to ignore VS Code configuration files. Merge this commit separately.